### PR TITLE
Fix fib code example, return i instead of 1

### DIFF
--- a/examples/code/imperative-programming/fib.mlt
+++ b/examples/code/imperative-programming/fib.mlt
@@ -28,7 +28,7 @@ let memoize f =
 [%%expect ocaml {|val memoize : ('a -> 'b) -> 'a -> 'b = <fun>|}];;
 [@@@part "1"];;
 let rec fib i =
-  if i <= 1 then 1 else fib (i - 1) + fib (i - 2);;
+  if i <= 1 then i else fib (i - 1) + fib (i - 2);;
 [%%expect ocaml {|val fib : int -> int = <fun>|}];;
 [@@@part "2"];;
 time (fun () -> fib 20);;


### PR DESCRIPTION
This error was found when running the different versions for the same number observing they produced different results:

utop # time (fun () -> fib 40);;
Time: 0.0348091125488 ms
- : int = 102334155

utop # time (fun () -> fib 40);;
Time: 0.0350475311279 ms
- : int = 165580141
